### PR TITLE
Run vis_homo.py with argument options

### DIFF
--- a/bev/io/utils.py
+++ b/bev/io/utils.py
@@ -90,7 +90,8 @@ def video_generator(video_name, height=None, width=None, img_folder=None, fps=30
                 filename=video_name,
                 # some installation of opencv may not support x264 (due to its license),
                 # you can try other format (e.g. MPEG)
-                # fourcc = cv2.VideoWriter_fourcc('M','J','P','G'),cv2.VideoWriter_fourcc(*"x264"),
+                # fourcc=cv2.VideoWriter_fourcc('M','J','P','G')
+                # fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
                 fourcc=cv2.VideoWriter_fourcc(*"x264"),
                 fps=float(fps),
                 frameSize=(width, height),

--- a/vis_homo.py
+++ b/vis_homo.py
@@ -1,10 +1,30 @@
+import argparse
 import bev
 import cv2
 import numpy as np
+import os
 
 from bev.constructor.homo_constr import load_calib, preset_bspec
+from bev.io.utils import video_generator
 from bev.visualizer.homo_vis import vis_bspec_and_calib_in_grid
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video-tag", type=str, default="5_left")
+    parser.add_argument("--video-path", type=str,
+        default="/media/sda1/datasets/extracted/BrnoCompSpeed/dataset/session{video_tag}/video.avi")
+    parser.add_argument("--calib-path", type=str,
+        default="/media/sda1/datasets/extracted/BrnoCompSpeed/calib/session{video_tag}/system_dubska_optimal_calib.json")
+    parser.add_argument("--no-grid", action="store_true", help="skip drawing the homographic grid plane")
+    parser.add_argument("--no-show", action="store_true", help="skip showing output frames while processing")
+    parser.add_argument("--no-small", action="store_true",
+        help="skip generating another bev from lower res source frames")
+    parser.add_argument("--write-vid", action="store_true", help="generate a bev and ori video for trafcam_3d")
+    parser.add_argument("--video-out-dir", type=str,
+        default="/media/sda1/datasets/extracted/bev/BrnoCompSpeed/session{video_tag}")
+    parser.add_argument("--calib-new-u", type=int, default=852)
+    parser.add_argument("--calib-new-v", type=int, default=480)
+    args = parser.parse_args()
 
     # img_path = "/media/sda1/datasets/extracted/KoPER/added/SK_1_empty_road_bev.png"
     # # img_path = "/media/sda1/datasets/extracted/KoPER/Sequence1a/KAB_SK_1_undist/KAB_SK_1_undist_1384779301359985.bmp"
@@ -16,15 +36,22 @@ if __name__ == "__main__":
     # cv2.imshow("img", img)
     # cv2.waitKey()
 
-    video_tag = "6_left"
+    video_tag = args.video_tag
     cam_id = int(video_tag[0])
     cam_sub = video_tag.split("_")[1]
     sub_id_dict = {"left":0.1, "center":0.2, "right":0.3}
     cam_id = cam_id + sub_id_dict[cam_sub]
     # print("cam_id", cam_id)
 
-    video_path = "/media/sda1/datasets/extracted/BrnoCompSpeed/dataset/session{}/video.avi".format(video_tag)
-    calib_path = "/media/sda1/datasets/extracted/BrnoCompSpeed/calib/session{}/system_dubska_optimal_calib.json".format(video_tag)
+    video_path = args.video_path.format(video_tag=video_tag) if args.video_path.find("{video_tag}") > -1 else args.video_path
+    calib_path = args.calib_path.format(video_tag=video_tag) if args.calib_path.find("{video_tag}") > -1 else args.calib_path
+    no_grid = args.no_grid
+    no_show = args.no_show
+    no_small = args.no_small or args.no_show
+    write_vid = args.write_vid
+    video_out_dir = args.video_out_dir.format(video_tag=video_tag) if args.video_out_dir.find("{video_tag}") > -1 else args.video_out_dir
+    video_out_bev_path = os.path.join(video_out_dir, "bev.mp4")
+    video_out_ori_path = os.path.join(video_out_dir, "ori.mp4")
 
     video = cv2.VideoCapture(video_path)    
     calib = load_calib("BrnoCompSpeed", calib_path)
@@ -40,8 +67,8 @@ if __name__ == "__main__":
     corners = bspec.gen_bev_corners_in_world()
     print("corners", corners)
 
-    new_u = 852
-    new_v = 480
+    new_u = args.calib_new_u
+    new_v = args.calib_new_v
     calib_small = calib.scale(align_corners=False, new_u=new_u, new_v=new_v)
     center_world_small = calib_small.gen_center_in_world()
     print("center_world_small", center_world_small)
@@ -49,24 +76,41 @@ if __name__ == "__main__":
     H_world_img_small = calib_small.gen_H_world_img()
     H_bev_img_small = np.linalg.inv(H_world_bev).dot(H_world_img_small)
 
+    video_out_bev = video_generator(video_out_bev_path, width=bspec.u_size, height=bspec.v_size) if write_vid else None
+    ori_width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
+    ori_height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    video_out_ori = video_generator(video_out_ori_path, width=ori_width, height=ori_height) if write_vid else None
+
     while video.isOpened():
-        _, img = video.read()
+        read_result, img = video.read()
+        if not read_result: break
+
         bev = cv2.warpPerspective(img, H_bev_img, (bspec.u_size, bspec.v_size))
+        img_small = None if no_small else cv2.resize(img, (new_u, new_v))
+        bev_small = None if no_small else cv2.warpPerspective(img_small, H_bev_img_small, (bspec.u_size, bspec.v_size))
 
-        img = vis_bspec_and_calib_in_grid(img, bspec, calib)
-        bev = vis_bspec_and_calib_in_grid(bev, bspec)
+        if not no_grid:
+            img_small = None if no_small else vis_bspec_and_calib_in_grid(img_small, bspec, calib)
+            bev_small = None if no_small else vis_bspec_and_calib_in_grid(bev_small, bspec)
+            img = vis_bspec_and_calib_in_grid(img, bspec, calib)
+            bev = vis_bspec_and_calib_in_grid(bev, bspec)
 
-        cv2.imshow("img", img)
-        cv2.imshow("bev", bev)
+        if not no_show:
+            cv2.imshow("img", img)
+            cv2.imshow("bev", bev)
 
-        img_small = cv2.resize(img, (new_u, new_v))
-        bev_small = cv2.warpPerspective(img_small, H_bev_img_small, (bspec.u_size, bspec.v_size))
+            if not no_small:
+                cv2.imshow("img_small", img_small)
+                cv2.imshow("bev_small", bev_small)
+            
+            cv2.waitKey(0)
 
-        img_small = vis_bspec_and_calib_in_grid(img_small, bspec, calib)
-        bev_small = vis_bspec_and_calib_in_grid(bev_small, bspec)
+        if write_vid:
+            video_out_ori.write(img)
+            video_out_bev.write(bev)
 
-        cv2.imshow("img_small", img_small)
-        cv2.imshow("bev_small", bev_small)
-        cv2.waitKey(0)
-        
-    video.close()
+    video.release()
+
+    if write_vid:
+        video_out_ori.release()
+        video_out_bev.release()


### PR DESCRIPTION
Hi @minghanz,

Thank you again for your guidance earlier! I'd like to contribute back to you with some script improvements that I made locally. I hope you like the changes.

I added the following argument options to support overriding some paths and values defined inline. A few are convenient feature toggles:

--video-tag, --video-path, --calib-path,
--no-grid, --no-show, --no-small, --write-vid,
--video-out-dir, --calib-new-u, --calib-new-v

I made sure all args are optional and that the script still runs by default with the same paths and features baked inline today. The one exception is the default video_tag which I changed from `6_left` to `5_left` just so it matched the sample data subset shared for testing trafcam_3d.

The --write-vid option adds support for generating ori and bev video files. They can be processed by the run_detect.sh and run_detect_vis.sh scripts in your yolov3 submodule of trafcam_3d. This was a key feature I needed to add recreate the steps in your paper end-to-end.

There's also a new comment line in utils.py where fourcc is configured. Just like you called out in your comment just above, I found that the Ubuntu 18.04 VM I was using did not have x264 available. The mp4v codec worked out great for me after trying a few options. As a convenience for the next person who is without x264, I hope you don't mind that I added a commented out line that's ready to enable mp4v.

If there are any changes you'd like to see, please let me know. I hope all is well with you in the meantime.

Thank you,

David